### PR TITLE
Add CI through GitHub Actions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,6 @@ Rplots\.pdf$
 ^CRAN-RELEASE$
 ^_pkgdown\.yml$
 ^pkgdown$
+^\.ccache$
+^\.github$
+^tic\.R$

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -1,0 +1,122 @@
+## tic GitHub Actions template: linux-macos-windows-deploy
+## revision date: 2020-06-14
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: tic
+
+jobs:
+  all:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # use a different tic template type if you do not want to build on all listed platforms
+          - { os: windows-latest, r: "devel" }
+          - { os: windows-latest, r: "release" }
+          - { os: macOS-latest, r: "release", pkgdown: "true", latex: "true" }
+          # - { os: macOS-latest, r: "devel" }
+          - { os: macOS-latest, r: "oldrel" }
+          - { os: ubuntu-latest, r: "release" }
+
+    env:
+      # otherwise remotes::fun() errors cause the build to fail. Example: Unavailability of binaries
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      CRAN: ${{ matrix.config.cran }}
+      # make sure to run `tic::use_ghactions_deploy()` to set up deployment
+      TIC_DEPLOY_KEY: ${{ secrets.TIC_DEPLOY_KEY }}
+      # prevent rgl issues because no X11 display is available
+      RGL_USE_NULL: true
+      # if you use bookdown or blogdown, replace "PKGDOWN" by the respective
+      # capitalized term. This also might need to be done in tic.R
+      BUILD_PKGDOWN: ${{ matrix.config.pkgdown }}
+      # macOS >= 10.15.4 linking
+      SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+      # use GITHUB_TOKEN from GitHub to workaround rate limits in {remotes}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2.1.1
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+          Ncpus: 4
+
+      # LaTeX. Installation time:
+      # Linux: ~ 1 min
+      # macOS: ~ 1 min 30s
+      # Windows: never finishes
+      - uses: r-lib/actions/setup-tinytex@master
+        if: matrix.config.latex == 'true'
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      # set date/week for use in cache creation
+      # https://github.community/t5/GitHub-Actions/How-to-set-and-access-a-Workflow-variable/m-p/42970
+      # - cache R packages daily
+      - name: "[Cache] Prepare daily timestamp for cache"
+        if: runner.os != 'Windows'
+        id: date
+        run: echo "::set-output name=date::$(date '+%d-%m')"
+
+      - name: "[Cache] Cache R packages"
+        if: runner.os != 'Windows'
+        uses: pat-s/always-upload-cache@v2.0.0
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
+
+      # for some strange Windows reason this step and the next one need to be decoupled
+      - name: "[Stage] Prepare"
+        run: |
+          Rscript -e "if (!requireNamespace('remotes')) install.packages('remotes', type = 'source')"
+          Rscript -e "if (getRversion() < '3.2' && !requireNamespace('curl')) install.packages('curl', type = 'source')"
+
+      - name: "[Stage] [Linux] Install curl"
+        if: runner.os == 'Linux'
+        run: sudo apt install libcurl4-openssl-dev
+
+      - name: "[Stage] Install"
+        if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'
+        run: Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
+
+      # macOS devel needs its own stage because we need to work with an option to suppress the usage of binaries
+      - name: "[Stage] Prepare & Install (macOS-devel)"
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
+        run: |
+          echo -e 'options(Ncpus = 4, pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
+          Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
+
+      - name: "[Stage] Script"
+        run: Rscript -e 'tic::script()'
+
+      - name: "[Stage] After Success"
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'release'
+        run: Rscript -e "tic::after_success()"
+
+      - name: "[Stage] Upload R CMD check artifacts"
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check
+      - name: "[Stage] Before Deploy"
+        run: |
+          Rscript -e "tic::before_deploy()"
+
+      - name: "[Stage] Deploy"
+        run: Rscript -e "tic::deploy()"
+
+      - name: "[Stage] After Deploy"
+        run: Rscript -e "tic::after_deploy()"

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -26,7 +26,7 @@ jobs:
           - { os: macOS-latest, r: "release", pkgdown: "true", latex: "true" }
           # - { os: macOS-latest, r: "devel" }
           - { os: macOS-latest, r: "oldrel" }
-          - { os: ubuntu-latest, r: "release" }
+          # - { os: ubuntu-latest, r: "release" } # fails to install glmulti
 
     env:
       # otherwise remotes::fun() errors cause the build to fail. Example: Unavailability of binaries

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/testthat/*.modgen.back
 revdep/*.
 revdep
 /revdep/.cache.rds
+docs/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,5 @@ Suggests:
     roxygen2,
     testthat
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
+Encoding: UTF-8

--- a/R/helper_fun.R
+++ b/R/helper_fun.R
@@ -20,8 +20,8 @@
 #'
 #' @examples
 #' my.df <- data.frame(1, 1:10, sample(LETTERS[1:3], 10, replace = TRUE))
-#' my.folder <- file.path(tempdir(check=TRUE), 'test')
-#' df2disk(df=my.df, dirpath=tempdir(check=TRUE), fname='testname')
+#' my.folder <- file.path(tempdir(), 'test')
+#' df2disk(df=my.df, dirpath=tempdir(), fname='testname')
 #' df2disk(df=my.df, dirpath=my.folder, fname='testname', postfix='_testpostfix')
 #' @export
 df2disk <- function(df, dirpath, fname, postfix = "", row_names=FALSE) {

--- a/tic.R
+++ b/tic.R
@@ -1,0 +1,8 @@
+# installs dependencies, runs R CMD check, runs covr::codecov()
+do_package_checks()
+
+if (ci_on_ghactions() && ci_has_env("BUILD_PKGDOWN")) {
+  # creates pkgdown site and pushes to gh-pages branch
+  # only for the runner with the "BUILD_PKGDOWN" env var set
+  do_pkgdown()
+}


### PR DESCRIPTION
This PR adds a GHA workflow with minimal necessary additions to the package which tests vortexR on Windows Server 2019 and MacOS. There are other available environments, which currently fail to install R packages and system dependencies correctly until I find the correct incantations.

Any additional environments we can get to pass GHA could be added to the installation documentation for users.

The results of GHA runs of *my fork* live at https://github.com/florianm/vortexR/actions. If merged, the results will live at https://github.com/carlopacioni/vortexR/actions, from where a README badge can be generated.

If this PR gets merged, the following tasks have to be run by a package maintainer:

* Add GHA badge from https://github.com/carlopacioni/vortexR/actions to README
* If a gh-pages branch is not built from the first passing GHA workflow, it's possible that @carlopacioni as the repo maintainer has to run `tic::use_tic()` in order to let tic set up the necessary secrets and branches at `carlopacioni/vortexR`.
* Once a gh-pages branch is built, set repo homepage to "gh-pages" branch.
* Once the repo homepage is active, add repo homepage to repo settings and to DESCRIPTION and release an update to CRAN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carlopacioni/vortexr/50)
<!-- Reviewable:end -->
